### PR TITLE
Bug fix for crashlytics.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ client API.
 
 ### Android specificities
 
-Update your `platforms/android/AndroidManifest.xm` file by adding your crashlytics API key :
+Update your `platforms/android/AndroidManifest.xml` file by adding your crashlytics API key :
 
     <?xml version='1.0' encoding='utf-8'?>
     <manifest android:hardwareAccelerated="true" android:versionCode="1" android:versionName="1.0.0" android:windowSoftInputMode="adjustPan" package="your.package.here" xmlns:android="http://schemas.android.com/apk/res/android">
@@ -21,6 +21,19 @@ Update your `platforms/android/AndroidManifest.xm` file by adding your crashlyti
         </application>
     ...
     </manifest>
+
+Download `crashlytics_build.xml` and add it to your `custom_rules.xml`:
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <project>
+        <import file="<PATH TO CRASHLYTICS FOLDER>/crashlytics/crashlytics_build.xml"/>
+        <target name="-pre-compile">
+            ...
+        </target>
+        <target name="-post-build">
+            ...
+        </target>
+    </project>
 
 ## Crashlytics
 

--- a/www/crashlytics.js
+++ b/www/crashlytics.js
@@ -16,13 +16,9 @@ var Crashlytics = function(){
         console.warn("navigator.crashlytics not defined : considering you're in dev mode and mocking it !");
         execCall = function(methodName, args){ console.log("[Crashlytics] Call to "+methodName+"("+Array.prototype.join.apply(args, [", "])+")"); }
     } else {
-        execCall = function(methodName, args){
-            var newArrayOfArgs = [];
-            for (var i = 0; i < args.length; i++) {
-                newArrayOfArgs[i] = args[i];
-            }
-            exec(function(){}, function (error){
-        }, "Crashlytics", methodName, newArrayOfArgs); };
+        execCall = function(methodName, args){ 
+            exec(function(){}, function (error){}, "Crashlytics", methodName, args.slice()); 
+        };
     }
 
     var self = this;

--- a/www/crashlytics.js
+++ b/www/crashlytics.js
@@ -16,7 +16,13 @@ var Crashlytics = function(){
         console.warn("navigator.crashlytics not defined : considering you're in dev mode and mocking it !");
         execCall = function(methodName, args){ console.log("[Crashlytics] Call to "+methodName+"("+Array.prototype.join.apply(args, [", "])+")"); }
     } else {
-        execCall = function(methodName, args){ exec(null, null, "Crashlytics", methodName, args); };
+        execCall = function(methodName, args){
+            var newArrayOfArgs = [];
+            for (var i = 0; i < args.length; i++) {
+                newArrayOfArgs[i] = args[i];
+            }
+            exec(function(){}, function (error){
+        }, "Crashlytics", methodName, newArrayOfArgs); };
     }
 
     var self = this;


### PR DESCRIPTION
Move args to a new Array fixes this bug.
We couldn't store anything. A fix of another fork that used [arg[0]] fixed single parameter sets like logException. This fix works for all the set functions. 
Also updated the readme file. Because we needed the crashlytics_build.xml to build
